### PR TITLE
Publishing the slides online to github pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,14 @@
+name: gh-pages publisher 🚀
+
+on:
+push:
+  branches: [ master ]
+
+jobs:
+publish-gh-pages:
+  runs-on: ubuntu-latest
+  steps:
+     - uses: actions/checkout@v2
+     - run: gh-pages -d . -r https://$GH_TOKEN@github.com/mvonballmo/HFU_21H__JAS_20I_doc.git
+     env:
+        GH_TOKEN: ${{secrets.SECRET_GITHUB_TOKEN}}


### PR DESCRIPTION
This pull request is a proposal to publish the actual slides to github pages to make viewing them more comfotable.

To make this work a secret `${{secrets.SECRET_GITHUB_TOKEN}}` must be created following this guidline: [GitHub Documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)